### PR TITLE
repositoryUrl now read from .changelog.json not from package.json

### DIFF
--- a/.changelog.json
+++ b/.changelog.json
@@ -1,6 +1,7 @@
 {
   "jiraUrl": "",
   "repoCompareUrl": "/compare/commits?targetBranch=refs%2Ftags%2F{{previousTag}}&sourceBranch=refs%2Ftags%2F{{currentTag}}",
+  "repositoryUrl": "https://github.com/KrekkieD/buenos-changelog",
   "targetsMarkdown": [
     "./dist/changelogtarget.md"
   ],

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,15 +40,10 @@ function getConfig () {
 
   const $packageJson = require($path.resolve($constants.GIT_ROOT, 'package.json'));
 
-  const config = Object.assign(
-    {},
-    DEFAULT_CONFIG,
-    { repositoryUrl: $packageJson.repository.url },
-    _readConfig()
-  );
+  const config = Object.assign({}, DEFAULT_CONFIG, _readConfig());
 
-    return getWriterOpts(config)
-      .then(writerOpts => Object.assign(config, { writerOpts }));
+  return getWriterOpts(config)
+    .then(writerOpts => Object.assign(config, { writerOpts }));
 
 }
 function _readConfig () {

--- a/lib/config.js
+++ b/lib/config.js
@@ -38,8 +38,6 @@ const DEFAULT_CONFIG = {
 
 function getConfig () {
 
-  const $packageJson = require($path.resolve($constants.GIT_ROOT, 'package.json'));
-
   const config = Object.assign({}, DEFAULT_CONFIG, _readConfig());
 
   return getWriterOpts(config)


### PR DESCRIPTION
- "repositoryUrl" field added to .changelog.json.
- config generation routine updated: "repositoryUrl" is now taken from .changelog.json not from package.json